### PR TITLE
Add advanced diagnostics: per-disk, GPU, network, CPU-throttling and process fault tracking

### DIFF
--- a/Analyzers/Health/DiskHealthAnalyzer.cs
+++ b/Analyzers/Health/DiskHealthAnalyzer.cs
@@ -1,35 +1,66 @@
+using System.Diagnostics.Eventing.Reader;
+
 namespace ComputerPerformanceReview.Analyzers.Health;
 
 public sealed class DiskHealthAnalyzer : IHealthSubAnalyzer
 {
     public string Domain => "Disk";
 
-    // Thresholds
     private const double DiskQueueThreshold = 2.0;
     private const int DiskQueueConsecutive = 2;
-    private const double DiskLatencyWarningMs = 50;   // 50ms for SSD concern
-    private const double DiskLatencyCriticalMs = 200;  // 200ms = serious
+    private const double DiskLatencyWarningMs = 50;
+    private const double DiskLatencyCriticalMs = 200;
     private const int DiskLatencyConsecutive = 2;
 
-    // State
     private int _consecutiveHighDiskQueue;
     private int _consecutiveHighDiskLatency;
+
+    private DateTime _lastStoragePoll = DateTime.MinValue;
+    private int _cachedStorageErrors;
 
     public void Collect(MonitorSampleBuilder builder)
     {
         try
         {
-            var data = WmiHelper.Query(
-                "SELECT CurrentDiskQueueLength, AvgDiskSecPerRead, AvgDiskSecPerWrite " +
-                "FROM Win32_PerfFormattedData_PerfDisk_PhysicalDisk WHERE Name='_Total'");
-            if (data.Count > 0)
+            var allDisks = WmiHelper.Query(
+                "SELECT Name, CurrentDiskQueueLength, AvgDiskSecPerRead, AvgDiskSecPerWrite, PercentDiskTime " +
+                "FROM Win32_PerfFormattedData_PerfDisk_PhysicalDisk");
+
+            if (allDisks.Count > 0)
             {
-                builder.DiskQueueLength = WmiHelper.GetValue<double>(data[0], "CurrentDiskQueueLength");
-                builder.AvgDiskSecRead = WmiHelper.GetValue<double>(data[0], "AvgDiskSecPerRead");
-                builder.AvgDiskSecWrite = WmiHelper.GetValue<double>(data[0], "AvgDiskSecPerWrite");
+                var instances = new List<DiskInstanceStat>();
+                foreach (var disk in allDisks)
+                {
+                    string name = WmiHelper.GetValue<string>(disk, "Name") ?? "Okänd";
+                    double queue = WmiHelper.GetValue<double>(disk, "CurrentDiskQueueLength");
+                    double readSec = WmiHelper.GetValue<double>(disk, "AvgDiskSecPerRead");
+                    double writeSec = WmiHelper.GetValue<double>(disk, "AvgDiskSecPerWrite");
+                    double busy = WmiHelper.GetValue<double>(disk, "PercentDiskTime");
+
+                    if (name.Equals("_Total", StringComparison.OrdinalIgnoreCase))
+                    {
+                        builder.DiskQueueLength = queue;
+                        builder.AvgDiskSecRead = readSec;
+                        builder.AvgDiskSecWrite = writeSec;
+                    }
+                    else if (!name.StartsWith("HarddiskVolume", StringComparison.OrdinalIgnoreCase))
+                    {
+                        instances.Add(new DiskInstanceStat(name, queue, readSec * 1000, writeSec * 1000, busy));
+                    }
+                }
+
+                builder.DiskInstances = instances.OrderByDescending(d => Math.Max(d.ReadLatencyMs, d.WriteLatencyMs)).Take(6).ToList();
             }
         }
         catch { }
+
+        if (DateTime.UtcNow - _lastStoragePoll > TimeSpan.FromMinutes(1))
+        {
+            _cachedStorageErrors = QueryRecentStorageErrors(15);
+            _lastStoragePoll = DateTime.UtcNow;
+        }
+
+        builder.StorageErrorsLast15Min = _cachedStorageErrors;
     }
 
     public HealthAssessment Analyze(MonitorSample current, IReadOnlyList<MonitorSample> history)
@@ -37,7 +68,10 @@ public sealed class DiskHealthAnalyzer : IHealthSubAnalyzer
         var events = new List<MonitorEvent>();
         int healthScore = 100;
 
-        // 1. Disk queue bottleneck
+        var worstDisk = current.DiskInstances
+            .OrderByDescending(d => Math.Max(d.ReadLatencyMs, d.WriteLatencyMs))
+            .FirstOrDefault();
+
         if (current.DiskQueueLength > DiskQueueThreshold)
         {
             _consecutiveHighDiskQueue++;
@@ -46,12 +80,13 @@ public sealed class DiskHealthAnalyzer : IHealthSubAnalyzer
                 bool isCritical = current.DiskQueueLength > 5;
                 healthScore -= isCritical ? 25 : 10;
                 events.Add(new MonitorEvent(
-                    DateTime.Now, "DiskBottleneck",
+                    DateTime.Now,
+                    "DiskBottleneck",
                     $"Disk I/O-flaskhals: kölängd {current.DiskQueueLength:F1} i {_consecutiveHighDiskQueue * 3} sekunder",
                     isCritical ? "Critical" : "Warning",
-                    "Kontrollera om Windows Update, antivirus eller indexering körs i bakgrunden. "
-                    + "Öppna Aktivitetshanteraren → Disk-kolumnen för att se vilken process som läser/skriver mest. "
-                    + "Om du har HDD: överväg att uppgradera till SSD. Rensa temp-filer med Diskrensning."));
+                    "Kontrollera bakgrundsprocesser. "
+                    + GetTopIoHint(current)
+                    + GetWorstDiskHint(worstDisk)));
             }
         }
         else
@@ -59,7 +94,6 @@ public sealed class DiskHealthAnalyzer : IHealthSubAnalyzer
             _consecutiveHighDiskQueue = 0;
         }
 
-        // 2. Disk latency warning (the real indicator of "slow disk")
         double maxLatencyMs = Math.Max(current.AvgDiskSecRead, current.AvgDiskSecWrite) * 1000;
         if (maxLatencyMs > DiskLatencyWarningMs)
         {
@@ -69,22 +103,30 @@ public sealed class DiskHealthAnalyzer : IHealthSubAnalyzer
                 bool isCritical = maxLatencyMs > DiskLatencyCriticalMs;
                 healthScore -= isCritical ? 30 : 15;
 
-                string diskType = maxLatencyMs > 100 ? "Om detta är en SSD kan det tyda på firmware-problem eller TRIM som inte fungerar. " : "";
                 events.Add(new MonitorEvent(
-                    DateTime.Now, "DiskLatency",
+                    DateTime.Now,
+                    "DiskLatency",
                     $"Disk-latens: Läs {current.AvgDiskSecRead * 1000:F1}ms, Skriv {current.AvgDiskSecWrite * 1000:F1}ms",
                     isCritical ? "Critical" : "Warning",
-                    $"Diskens svarstid är onormalt hög ({maxLatencyMs:F0}ms). Normal SSD: <5ms, HDD: <20ms. "
-                    + diskType
-                    + "ÅTGÄRDER: 1) Kontrollera diskens hälsa med CrystalDiskInfo. "
-                    + "2) Kör TRIM manuellt: 'Optimize-Volume -DriveLetter C -ReTrim' i admin PowerShell. "
-                    + "3) Om HDD → uppgradera till SSD. "
-                    + "4) Kontrollera att AHCI är aktiverat i BIOS."));
+                    $"Diskens svarstid är hög ({maxLatencyMs:F0}ms). "
+                    + GetTopIoHint(current)
+                    + GetWorstDiskHint(worstDisk)));
             }
         }
         else
         {
             _consecutiveHighDiskLatency = 0;
+        }
+
+        if (current.StorageErrorsLast15Min > 0)
+        {
+            healthScore -= current.StorageErrorsLast15Min > 5 ? 30 : 15;
+            events.Add(new MonitorEvent(
+                DateTime.Now,
+                "StorageReset",
+                $"Lagringsfel i systemloggen: {current.StorageErrorsLast15Min} senaste 15 min",
+                current.StorageErrorsLast15Min > 5 ? "Critical" : "Warning",
+                "Disk/controller rapporterar fel eller timeout (ex. Event ID 129/153/7/51). Kontrollera kablar, firmware, drivrutiner och diskhälsa."));
         }
 
         healthScore = Math.Clamp(healthScore, 0, 100);
@@ -94,8 +136,58 @@ public sealed class DiskHealthAnalyzer : IHealthSubAnalyzer
             ? "Hög disklatens: I/O-operationer tar för lång tid"
             : null;
 
-        return new HealthAssessment(
-            new HealthScore(Domain, healthScore, confidence, hint),
-            events);
+        return new HealthAssessment(new HealthScore(Domain, healthScore, confidence, hint), events);
+    }
+
+    private static string GetTopIoHint(MonitorSample sample)
+    {
+        if (sample.TopIoProcesses.Count == 0)
+            return "Ingen I/O-process kunde identifieras i detta sample. ";
+
+        var top = sample.TopIoProcesses.Take(3)
+            .Select(proc => $"{proc.Name} ({ConsoleHelper.FormatBytes((long)proc.TotalBytes)})");
+
+        return $"Största I/O-processer: {string.Join(", ", top)}. ";
+    }
+
+    private static string GetWorstDiskHint(DiskInstanceStat? disk)
+    {
+        if (disk is null)
+            return string.Empty;
+
+        return $"Värst disk: {disk.Name} (R {disk.ReadLatencyMs:F1}ms, W {disk.WriteLatencyMs:F1}ms, kö {disk.QueueLength:F1}, busy {disk.BusyPercent:F0}%).";
+    }
+
+    private static int QueryRecentStorageErrors(int windowMinutes)
+    {
+        try
+        {
+            string xPath = "*[System[(Level=2 or Level=3) and "
+                + "(EventID=7 or EventID=51 or EventID=129 or EventID=153) and "
+                + $"TimeCreated[timediff(@SystemTime) <= {windowMinutes * 60 * 1000}]]]";
+
+            var query = new EventLogQuery("System", PathType.LogName, xPath)
+            {
+                ReverseDirection = true
+            };
+
+            using var reader = new EventLogReader(query);
+            int count = 0;
+            while (reader.ReadEvent() is EventRecord rec)
+            {
+                using (rec)
+                {
+                    count++;
+                    if (count >= 50)
+                        break;
+                }
+            }
+
+            return count;
+        }
+        catch
+        {
+            return 0;
+        }
     }
 }

--- a/Analyzers/Health/FreezeDetector.cs
+++ b/Analyzers/Health/FreezeDetector.cs
@@ -23,6 +23,31 @@ public static class FreezeDetector
                 + "Om SSD: kontrollera TRIM och firmware. Om HDD: överväg SSD-uppgradering.");
         }
 
+
+        if (sample.GpuUtilizationPercent > 95)
+        {
+            return new FreezeClassification(
+                processName,
+                "GPU-mättnad",
+                $"GPU ligger på {sample.GpuUtilizationPercent:F0}%. UI-rendering kan blockeras av grafikbelastning eller drivrutinsproblem.");
+        }
+
+        if (sample.DnsLatencyMs > 300)
+        {
+            return new FreezeClassification(
+                processName,
+                "Nätverkslatens",
+                $"DNS-latens är {sample.DnsLatencyMs:F0}ms. Processen kan vänta på nätverkssvar trots låg CPU/disk.");
+        }
+
+        if (sample.StorageErrorsLast15Min > 0)
+        {
+            return new FreezeClassification(
+                processName,
+                "Lagringsfel",
+                $"Systemloggen visar {sample.StorageErrorsLast15Min} lagringsfel senaste 15 min. Controller/disk-timeouts kan orsaka hängningar.");
+        }
+
         // CPU-mättnad: processorn är fullt belastad
         if (sample.CpuPercent > 80)
         {

--- a/Analyzers/Health/GpuHealthAnalyzer.cs
+++ b/Analyzers/Health/GpuHealthAnalyzer.cs
@@ -1,0 +1,149 @@
+using System.Diagnostics.Eventing.Reader;
+
+namespace ComputerPerformanceReview.Analyzers.Health;
+
+public sealed class GpuHealthAnalyzer : IHealthSubAnalyzer
+{
+    public string Domain => "GPU";
+
+    private int _consecutiveHighGpu;
+    private int _consecutiveHighVram;
+    private DateTime _lastTdrPoll = DateTime.MinValue;
+    private int _cachedTdrEvents;
+
+    public void Collect(MonitorSampleBuilder builder)
+    {
+        try
+        {
+            var gpuData = WmiHelper.Query(
+                "SELECT Name, UtilizationPercentage FROM Win32_PerfFormattedData_GPUPerformanceCounters_GPUEngine");
+
+            var gpuEngines = gpuData
+                .Where(d => (WmiHelper.GetValue<string>(d, "Name") ?? string.Empty).Contains("engtype_3D", StringComparison.OrdinalIgnoreCase))
+                .Select(d => WmiHelper.GetValue<double>(d, "UtilizationPercentage"));
+
+            builder.GpuUtilizationPercent = gpuEngines.Any() ? gpuEngines.Sum() : 0;
+        }
+        catch { }
+
+        try
+        {
+            var memData = WmiHelper.Query(
+                "SELECT DedicatedUsage, SharedUsage FROM Win32_PerfFormattedData_GPUPerformanceCounters_GPUAdapterMemory");
+
+            if (memData.Count > 0)
+            {
+                long dedicatedUsage = memData.Sum(d => WmiHelper.GetValue<long>(d, "DedicatedUsage"));
+                long sharedUsage = memData.Sum(d => WmiHelper.GetValue<long>(d, "SharedUsage"));
+                builder.GpuDedicatedUsageBytes = dedicatedUsage;
+                builder.GpuDedicatedLimitBytes = Math.Max(dedicatedUsage + sharedUsage, 1);
+            }
+        }
+        catch { }
+
+        if (DateTime.UtcNow - _lastTdrPoll > TimeSpan.FromMinutes(1))
+        {
+            _cachedTdrEvents = QueryRecentTdrEvents(15);
+            _lastTdrPoll = DateTime.UtcNow;
+        }
+
+        builder.TdrEventsLast15Min = _cachedTdrEvents;
+    }
+
+    public HealthAssessment Analyze(MonitorSample current, IReadOnlyList<MonitorSample> history)
+    {
+        var events = new List<MonitorEvent>();
+        int healthScore = 100;
+
+        if (current.GpuUtilizationPercent > 95)
+        {
+            _consecutiveHighGpu++;
+            if (_consecutiveHighGpu == 2)
+            {
+                healthScore -= 15;
+                events.Add(new MonitorEvent(
+                    DateTime.Now,
+                    "GpuSaturation",
+                    $"GPU-mättnad: {current.GpuUtilizationPercent:F0}%",
+                    "Warning",
+                    "GPU är hårt belastad. Uppdatera GPU-drivrutinen och sänk grafikbelastning för att minska UI-stutter."));
+            }
+        }
+        else
+        {
+            _consecutiveHighGpu = 0;
+        }
+
+        if (current.GpuDedicatedLimitBytes > 0)
+        {
+            double vramRatio = (double)current.GpuDedicatedUsageBytes / current.GpuDedicatedLimitBytes;
+            if (vramRatio > 0.9)
+            {
+                _consecutiveHighVram++;
+                if (_consecutiveHighVram == 2)
+                {
+                    healthScore -= 15;
+                    events.Add(new MonitorEvent(
+                        DateTime.Now,
+                        "GpuVramPressure",
+                        $"VRAM-tryck: {vramRatio * 100:F0}%",
+                        vramRatio > 0.98 ? "Critical" : "Warning",
+                        "VRAM är nästan full. Detta kan ge hitching/frysningar. Minska upplösning/texturkvalitet och stäng GPU-tunga appar."));
+                }
+            }
+            else
+            {
+                _consecutiveHighVram = 0;
+            }
+        }
+
+        if (current.TdrEventsLast15Min > 0)
+        {
+            healthScore -= current.TdrEventsLast15Min > 3 ? 30 : 15;
+            events.Add(new MonitorEvent(
+                DateTime.Now,
+                "GpuTdr",
+                $"GPU TDR/återställningar: {current.TdrEventsLast15Min} senaste 15 min",
+                current.TdrEventsLast15Min > 3 ? "Critical" : "Warning",
+                "Display-drivrutinen återställs (Event ID 4101). Uppdatera/drivrutins-rulla tillbaka, kontrollera temperatur/instabil OC."));
+        }
+
+        healthScore = Math.Clamp(healthScore, 0, 100);
+        double confidence = history.Count >= 3 ? 1.0 : history.Count / 3.0;
+        string? hint = current.TdrEventsLast15Min > 0 ? "GPU-drivrutin instabil (TDR-events)" : null;
+
+        return new HealthAssessment(new HealthScore(Domain, healthScore, confidence, hint), events);
+    }
+
+    private static int QueryRecentTdrEvents(int windowMinutes)
+    {
+        try
+        {
+            string xPath = "*[System[(Provider[@Name='Display']) and (EventID=4101) and "
+                + $"TimeCreated[timediff(@SystemTime) <= {windowMinutes * 60 * 1000}]]]";
+
+            var query = new EventLogQuery("System", PathType.LogName, xPath)
+            {
+                ReverseDirection = true
+            };
+
+            using var reader = new EventLogReader(query);
+            int count = 0;
+            while (reader.ReadEvent() is EventRecord rec)
+            {
+                using (rec)
+                {
+                    count++;
+                    if (count >= 50)
+                        break;
+                }
+            }
+
+            return count;
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+}

--- a/Analyzers/Health/NetworkLatencyHealthAnalyzer.cs
+++ b/Analyzers/Health/NetworkLatencyHealthAnalyzer.cs
@@ -1,0 +1,68 @@
+using System.Net;
+
+namespace ComputerPerformanceReview.Analyzers.Health;
+
+public sealed class NetworkLatencyHealthAnalyzer : IHealthSubAnalyzer
+{
+    public string Domain => "NetworkLatency";
+
+    private DateTime _lastProbe = DateTime.MinValue;
+    private double _cachedDnsLatencyMs;
+    private int _consecutiveHighLatency;
+
+    public void Collect(MonitorSampleBuilder builder)
+    {
+        if (DateTime.UtcNow - _lastProbe > TimeSpan.FromSeconds(15))
+        {
+            _cachedDnsLatencyMs = MeasureDnsLatency("www.microsoft.com");
+            _lastProbe = DateTime.UtcNow;
+        }
+
+        builder.DnsLatencyMs = _cachedDnsLatencyMs;
+    }
+
+    public HealthAssessment Analyze(MonitorSample current, IReadOnlyList<MonitorSample> history)
+    {
+        var events = new List<MonitorEvent>();
+        int healthScore = 100;
+
+        if (current.DnsLatencyMs > 300)
+        {
+            _consecutiveHighLatency++;
+            if (_consecutiveHighLatency == 2)
+            {
+                bool critical = current.DnsLatencyMs > 1000;
+                healthScore -= critical ? 20 : 10;
+                events.Add(new MonitorEvent(
+                    DateTime.Now,
+                    "DnsLatency",
+                    $"Hög DNS-latens: {current.DnsLatencyMs:F0} ms",
+                    critical ? "Critical" : "Warning",
+                    "Hög DNS-latens kan ge UI-häng i appar som väntar på nätverk. Kontrollera DNS-server, VPN och nätverksdrivrutin."));
+            }
+        }
+        else
+        {
+            _consecutiveHighLatency = 0;
+        }
+
+        double confidence = history.Count >= 3 ? 1.0 : history.Count / 3.0;
+        string? hint = current.DnsLatencyMs > 300 ? "Hög nätverkslatens (DNS)" : null;
+        return new HealthAssessment(new HealthScore(Domain, Math.Clamp(healthScore, 0, 100), confidence, hint), events);
+    }
+
+    private static double MeasureDnsLatency(string host)
+    {
+        try
+        {
+            var sw = Stopwatch.StartNew();
+            _ = Dns.GetHostAddresses(host);
+            sw.Stop();
+            return sw.Elapsed.TotalMilliseconds;
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+}

--- a/Analyzers/Health/SystemHealthEngine.cs
+++ b/Analyzers/Health/SystemHealthEngine.cs
@@ -40,6 +40,9 @@ public sealed class SystemHealthEngine
     private readonly List<long> _poolPagedSamples = [];
     private readonly List<int> _memPressureSamples = [];
     private readonly List<int> _latencyScoreSamples = [];
+    private readonly List<double> _gpuUtilSamples = [];
+    private readonly List<double> _dnsLatencySamples = [];
+    private readonly List<int> _storageErrorSamples = [];
     private int _freezeCount;
 
     public List<MonitorEvent> AllEvents { get; } = [];
@@ -52,6 +55,8 @@ public sealed class SystemHealthEngine
             new MemoryHealthAnalyzer(),
             new CpuSchedulerHealthAnalyzer(),
             new DiskHealthAnalyzer(),
+            new GpuHealthAnalyzer(),
+            new NetworkLatencyHealthAnalyzer(),
             _processAnalyzer
         ];
         InitializeNetworkBaseline();
@@ -142,6 +147,9 @@ public sealed class SystemHealthEngine
             PeakAvgDiskSecWrite: SafeMax(_diskSecWriteSamples),
             PeakPoolNonpagedBytes: _poolNonpagedSamples.Count > 0 ? _poolNonpagedSamples.Max() : 0,
             PeakPoolPagedBytes: _poolPagedSamples.Count > 0 ? _poolPagedSamples.Max() : 0,
+            PeakGpuUtilizationPercent: SafeMax(_gpuUtilSamples),
+            PeakDnsLatencyMs: SafeMax(_dnsLatencySamples),
+            PeakStorageErrorsLast15Min: _storageErrorSamples.Count > 0 ? _storageErrorSamples.Max() : 0,
             AvgMemoryPressureIndex: _memPressureSamples.Count > 0 ? (int)_memPressureSamples.Average() : 0,
             PeakMemoryPressureIndex: _memPressureSamples.Count > 0 ? _memPressureSamples.Max() : 0,
             AvgSystemLatencyScore: _latencyScoreSamples.Count > 0 ? (int)_latencyScoreSamples.Average() : 0,
@@ -349,6 +357,9 @@ public sealed class SystemHealthEngine
         _poolPagedSamples.Add(s.PoolPagedBytes);
         _memPressureSamples.Add(s.MemoryPressureIndex);
         _latencyScoreSamples.Add(s.SystemLatencyScore);
+        _gpuUtilSamples.Add(s.GpuUtilizationPercent);
+        _dnsLatencySamples.Add(s.DnsLatencyMs);
+        _storageErrorSamples.Add(s.StorageErrorsLast15Min);
     }
 
     private static double SafeAvg(List<double> list) => list.Count > 0 ? list.Average() : 0;

--- a/Helpers/NativeMethods.cs
+++ b/Helpers/NativeMethods.cs
@@ -10,6 +10,21 @@ public static partial class NativeMethods
     [LibraryImport("user32.dll")]
     private static partial uint GetGuiResources(IntPtr hProcess, uint uiFlags);
 
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool GetProcessIoCounters(IntPtr hProcess, out IoCounters counters);
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct IoCounters
+    {
+        public ulong ReadOperationCount;
+        public ulong WriteOperationCount;
+        public ulong OtherOperationCount;
+        public ulong ReadTransferCount;
+        public ulong WriteTransferCount;
+        public ulong OtherTransferCount;
+    }
+
     public static (int GdiObjects, int UserObjects) GetGuiResourceCounts(IntPtr processHandle)
     {
         try
@@ -21,6 +36,19 @@ public static partial class NativeMethods
         catch
         {
             return (0, 0);
+        }
+    }
+
+    public static bool TryGetIoCounters(IntPtr processHandle, out IoCounters counters)
+    {
+        try
+        {
+            return GetProcessIoCounters(processHandle, out counters);
+        }
+        catch
+        {
+            counters = default;
+            return false;
         }
     }
 }

--- a/Helpers/ProcessExtensions.cs
+++ b/Helpers/ProcessExtensions.cs
@@ -1,0 +1,21 @@
+namespace ComputerPerformanceReview.Helpers;
+
+public static class ProcessExtensions
+{
+    public static bool TryGetIoCounters(this Process process, out NativeMethods.IoCounters counters)
+    {
+        counters = default;
+
+        try
+        {
+            if (process.HasExited)
+                return false;
+
+            return NativeMethods.TryGetIoCounters(process.Handle, out counters);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/Models/MonitorSample.cs
+++ b/Models/MonitorSample.cs
@@ -3,7 +3,6 @@ using System.Text.Json.Serialization;
 namespace ComputerPerformanceReview.Models;
 
 public sealed record MonitorSample(
-    // --- Grundläggande (befintliga) ---
     DateTime Timestamp,
     double CpuPercent,
     double MemoryUsedPercent,
@@ -16,36 +15,36 @@ public sealed record MonitorSample(
     List<MonitorProcessInfo> TopCpuProcesses,
     List<MonitorProcessInfo> TopMemoryProcesses,
     List<MonitorProcessInfo> TopGdiProcesses,
+    List<MonitorIoProcessInfo> TopIoProcesses,
+    List<MonitorFaultProcessInfo> TopFaultProcesses,
+    List<DiskInstanceStat> DiskInstances,
     List<HangingProcessInfo> HangingProcesses,
-
-    // --- Nya minnesfält ---
     double PagesInputPerSec = 0,
     double PagesOutputPerSec = 0,
     long CommitLimit = 0,
     long AvailableMBytes = 0,
     long PoolNonpagedBytes = 0,
     long PoolPagedBytes = 0,
-
-    // --- Nya CPU/scheduler-fält ---
     double ContextSwitchesPerSec = 0,
     int ProcessorQueueLength = 0,
     double DpcTimePercent = 0,
     double InterruptTimePercent = 0,
-
-    // --- Nya diskfält ---
     double AvgDiskSecRead = 0,
     double AvgDiskSecWrite = 0,
-
-    // --- Composite scores (beräknade, inte insamlade) ---
+    double CpuClockMHz = 0,
+    double CpuMaxClockMHz = 0,
+    double GpuUtilizationPercent = 0,
+    long GpuDedicatedUsageBytes = 0,
+    long GpuDedicatedLimitBytes = 0,
+    double DnsLatencyMs = 0,
+    int StorageErrorsLast15Min = 0,
+    int TdrEventsLast15Min = 0,
     int MemoryPressureIndex = 0,
     int SystemLatencyScore = 0,
     FreezeClassification? FreezeInfo = null
 );
 
-public sealed record HangingProcessInfo(
-    string Name,
-    double HangSeconds
-);
+public sealed record HangingProcessInfo(string Name, double HangSeconds);
 
 public sealed record MonitorProcessInfo(
     string Name,
@@ -57,6 +56,10 @@ public sealed record MonitorProcessInfo(
     int UserObjects,
     int ThreadCount = 0
 );
+
+public sealed record MonitorIoProcessInfo(string Name, int Pid, ulong ReadBytes, ulong WriteBytes, ulong TotalBytes);
+public sealed record MonitorFaultProcessInfo(string Name, int Pid, double PageFaultsPerSec);
+public sealed record DiskInstanceStat(string Name, double QueueLength, double ReadLatencyMs, double WriteLatencyMs, double BusyPercent);
 
 public sealed record MonitorEvent(
     DateTime Timestamp,
@@ -71,7 +74,6 @@ public sealed record MonitorReport(
     DateTime EndTime,
     int TotalSamples,
     List<MonitorEvent> Events,
-    // Befintliga
     double AvgCpu,
     double PeakCpu,
     double AvgMemory,
@@ -83,7 +85,6 @@ public sealed record MonitorReport(
     long PeakSystemHandles,
     double PeakPageFaults,
     long PeakCommittedBytes,
-    // Nya
     double PeakPagesInputPerSec = 0,
     double PeakDpcTimePercent = 0,
     double PeakInterruptTimePercent = 0,
@@ -93,6 +94,9 @@ public sealed record MonitorReport(
     double PeakAvgDiskSecWrite = 0,
     long PeakPoolNonpagedBytes = 0,
     long PeakPoolPagedBytes = 0,
+    double PeakGpuUtilizationPercent = 0,
+    double PeakDnsLatencyMs = 0,
+    int PeakStorageErrorsLast15Min = 0,
     int AvgMemoryPressureIndex = 0,
     int PeakMemoryPressureIndex = 0,
     int AvgSystemLatencyScore = 0,

--- a/Models/MonitorSampleBuilder.cs
+++ b/Models/MonitorSampleBuilder.cs
@@ -1,12 +1,7 @@
 namespace ComputerPerformanceReview.Models;
 
-/// <summary>
-/// Mutabel builder för MonitorSample. Sub-analyzers populerar sina fält,
-/// sedan anropas Build() för att skapa det immutabla recordet.
-/// </summary>
 public sealed class MonitorSampleBuilder
 {
-    // Grundläggande
     public DateTime Timestamp { get; set; } = DateTime.Now;
     public double CpuPercent { get; set; }
     public double MemoryUsedPercent { get; set; }
@@ -19,9 +14,11 @@ public sealed class MonitorSampleBuilder
     public List<MonitorProcessInfo> TopCpuProcesses { get; set; } = [];
     public List<MonitorProcessInfo> TopMemoryProcesses { get; set; } = [];
     public List<MonitorProcessInfo> TopGdiProcesses { get; set; } = [];
+    public List<MonitorIoProcessInfo> TopIoProcesses { get; set; } = [];
+    public List<MonitorFaultProcessInfo> TopFaultProcesses { get; set; } = [];
+    public List<DiskInstanceStat> DiskInstances { get; set; } = [];
     public List<HangingProcessInfo> HangingProcesses { get; set; } = [];
 
-    // Nya minnesfält
     public double PagesInputPerSec { get; set; }
     public double PagesOutputPerSec { get; set; }
     public long CommitLimit { get; set; }
@@ -29,17 +26,23 @@ public sealed class MonitorSampleBuilder
     public long PoolNonpagedBytes { get; set; }
     public long PoolPagedBytes { get; set; }
 
-    // Nya CPU/scheduler-fält
     public double ContextSwitchesPerSec { get; set; }
     public int ProcessorQueueLength { get; set; }
     public double DpcTimePercent { get; set; }
     public double InterruptTimePercent { get; set; }
 
-    // Nya diskfält
     public double AvgDiskSecRead { get; set; }
     public double AvgDiskSecWrite { get; set; }
 
-    // Composite scores (sätts av engine efter Collect)
+    public double CpuClockMHz { get; set; }
+    public double CpuMaxClockMHz { get; set; }
+    public double GpuUtilizationPercent { get; set; }
+    public long GpuDedicatedUsageBytes { get; set; }
+    public long GpuDedicatedLimitBytes { get; set; }
+    public double DnsLatencyMs { get; set; }
+    public int StorageErrorsLast15Min { get; set; }
+    public int TdrEventsLast15Min { get; set; }
+
     public int MemoryPressureIndex { get; set; }
     public int SystemLatencyScore { get; set; }
     public FreezeClassification? FreezeInfo { get; set; }
@@ -57,6 +60,9 @@ public sealed class MonitorSampleBuilder
         TopCpuProcesses: TopCpuProcesses,
         TopMemoryProcesses: TopMemoryProcesses,
         TopGdiProcesses: TopGdiProcesses,
+        TopIoProcesses: TopIoProcesses,
+        TopFaultProcesses: TopFaultProcesses,
+        DiskInstances: DiskInstances,
         HangingProcesses: HangingProcesses,
         PagesInputPerSec: PagesInputPerSec,
         PagesOutputPerSec: PagesOutputPerSec,
@@ -70,6 +76,14 @@ public sealed class MonitorSampleBuilder
         InterruptTimePercent: InterruptTimePercent,
         AvgDiskSecRead: AvgDiskSecRead,
         AvgDiskSecWrite: AvgDiskSecWrite,
+        CpuClockMHz: CpuClockMHz,
+        CpuMaxClockMHz: CpuMaxClockMHz,
+        GpuUtilizationPercent: GpuUtilizationPercent,
+        GpuDedicatedUsageBytes: GpuDedicatedUsageBytes,
+        GpuDedicatedLimitBytes: GpuDedicatedLimitBytes,
+        DnsLatencyMs: DnsLatencyMs,
+        StorageErrorsLast15Min: StorageErrorsLast15Min,
+        TdrEventsLast15Min: TdrEventsLast15Min,
         MemoryPressureIndex: MemoryPressureIndex,
         SystemLatencyScore: SystemLatencyScore,
         FreezeInfo: FreezeInfo


### PR DESCRIPTION
### Motivation
- Provide deeper root-cause visibility for freezes/stutters that aren’t explained by CPU usage alone by collecting per-disk latency, GPU health, DNS latency, process page-fault pressure and storage errors. 
- Surface these signals end-to-end (collection → analysis → UI/report) so the monitor can suggest actionable recommendations when UI hangs occur.

### Description
- Added new health analyzers `GpuHealthAnalyzer` and `NetworkLatencyHealthAnalyzer` and integrated them into `SystemHealthEngine` to collect GPU utilization/VRAM pressure, TDR events and DNS latency probes.  
- Extended `DiskHealthAnalyzer` to collect per-disk stats (`DiskInstanceStat`), expose a "worst disk" hint, poll System event log for recent storage errors, and generate latency / queue / storage events.  
- Enhanced `ProcessHealthAnalyzer` to measure per-process page-fault deltas (`MonitorFaultProcessInfo`) and per-process I/O via `TryGetIoCounters`, and expose top fault- and I/O-heavy processes to UI and analyzers.  
- Expanded data model: `MonitorSample`, `MonitorSampleBuilder` and `MonitorReport` now include GPU/DNS/storage/throttling fields, `MonitorFaultProcessInfo`, `MonitorIoProcessInfo`, and `DiskInstanceStat` so new signals flow through the engine; added `MonitorDisplay` updates to render CPU clock ratio, GPU %, DNS latency, storage error counts, top fault processes and worst-disk details.  
- Added utility and analyzer improvements: faster directory sizing (`GetDirectorySizeFast`), disk latency/busy checks and SMART queries in `DiskAnalyzer`, `NativeMethods` IoCounters + `ProcessExtensions.TryGetIoCounters`, and `SystemAnalyzer` added pagefile-location discovery for diagnostics.

### Testing
- Ran `git diff --check` which returned no whitespace/patch issues (success).  
- Attempted `dotnet build` in this environment but the `dotnet` tool is not available so a build could not be executed here (`bash: command not found: dotnet`).  
- Performed local code validation steps (static listing/grep and manual reviews of modified files) and committed the changes with a descriptive commit message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cfdbe48a0832797c5b31ba6e6c03d)